### PR TITLE
Correct SliceBridge 3D Slicer workflow

### DIFF
--- a/Tutorial/SliceBridgeJP.md
+++ b/Tutorial/SliceBridgeJP.md
@@ -104,12 +104,41 @@ segref3d_labelmap_anchor_z0p65mm.nii.gz
 2. SliceBridgeからダウンロードした`.nii.gz`を選びます。
 3. `Description`を`Volume`にして読み込みます。
 
-### 5-2. Segmentationへ変換する
+### 5-2. Segment Editorへ移動する
 
-`Segmentations`モジュールで、読み込んだlabelmapをSegmentationへ
-インポートします。
+1. `Segment Editor`モジュールを開きます。
+2. `Source volume`で、読み込んだNIfTI Volumeを選択します。
+3. `Add`を押して、空のセグメントを1つ作ります。
 
-### 5-3. セグメントの重なりを許可する
+### 5-3. ラベル値1を抽出する
+
+1. 作成したセグメントを選択します。
+2. エフェクトから`Threshold`を選択します。
+3. `Threshold Range`の下限と上限を、どちらも`1.00`にします。
+4. `Apply`を押します。
+
+これで、Volume内のラベル値`1`の領域だけが最初のセグメントへ入ります。
+
+### 5-4. 他の整数ラベル値も順に抽出する
+
+ラベル値`2`以降も、整数値ごとにセグメントを分けて抽出します。
+
+1. 再度`Add`を押し、新しい空のセグメントを作ります。
+2. `Threshold`を選択します。
+3. ラベル値`2`なら、Rangeを`2.00–2.00`にして`Apply`します。
+4. ラベル値`3`なら、さらに`Add`して、Rangeを`3.00–3.00`にして`Apply`します。
+5. NIfTIに含まれる整数ラベル値の分だけ繰り返します。
+
+```text
+ラベル値1：Add → Threshold → 1.00–1.00 → Apply
+ラベル値2：Add → Threshold → 2.00–2.00 → Apply
+ラベル値3：Add → Threshold → 3.00–3.00 → Apply
+```
+
+SliceBridgeの読み込み画面に表示された`ラベル`の整数値だけを作成すれば十分です。
+必要に応じて、各セグメントを骨盤骨、内閉鎖筋、肛門挙筋などの名称へ変更します。
+
+### 5-5. セグメントの重なりを許可する
 
 `Segment Editor`で、以下を設定します。
 
@@ -117,16 +146,16 @@ segref3d_labelmap_anchor_z0p65mm.nii.gz
 Modify other segments → Allow overlap
 ```
 
-骨盤骨、内閉鎖筋、肛門挙筋など、複数の構造を同時に扱う場合に重要です。
+複数の構造を補間した結果、境界部分でセグメント同士が接触・重複する可能性が
+あるため、Fill between slicesを行う前に設定します。
 
-### 5-4. Fill between slicesを実行する
+### 5-6. Fill between slicesを実行する
 
-1. 補間するセグメントを選択します。
+1. 補間するセグメントを1つ選択します。
 2. `Fill between slices`を選択します。
 3. `Initialize`で補間結果を確認します。
 4. 問題がなければ`Apply`を押します。
-5. 複数のセグメントがある場合は、各セグメントで繰り返します。
-
+5. 作成した各セグメントで同じ操作を繰り返します。
 ---
 
 ## 使用上の注意

--- a/Tutorial/SliceBridgeJP.md
+++ b/Tutorial/SliceBridgeJP.md
@@ -138,24 +138,22 @@ segref3d_labelmap_anchor_z0p65mm.nii.gz
 SliceBridgeの読み込み画面に表示された`ラベル`の整数値だけを作成すれば十分です。
 必要に応じて、各セグメントを骨盤骨、内閉鎖筋、肛門挙筋などの名称へ変更します。
 
-### 5-5. セグメントの重なりを許可する
+### 5-5. 各セグメントでFill between slicesを実行する
 
-`Segment Editor`で、以下を設定します。
-
-```text
-Modify other segments → Allow overlap
-```
-
-複数の構造を補間した結果、境界部分でセグメント同士が接触・重複する可能性が
-あるため、Fill between slicesを行う前に設定します。
-
-### 5-6. Fill between slicesを実行する
+作成したセグメントを1つずつ補間します。
 
 1. 補間するセグメントを1つ選択します。
 2. `Fill between slices`を選択します。
-3. `Initialize`で補間結果を確認します。
+3. `Initialize`を押して補間結果を確認します。
 4. 問題がなければ`Apply`を押します。
-5. 作成した各セグメントで同じ操作を繰り返します。
+5. 次のセグメントを選択し、同じく`Initialize`、`Apply`を行います。
+6. 作成したすべてのセグメントで繰り返します。
+
+```text
+Segment_1を選択 → Fill between slices → Initialize → Apply
+Segment_2を選択 → Fill between slices → Initialize → Apply
+Segment_3を選択 → Fill between slices → Initialize → Apply
+```
 ---
 
 ## 使用上の注意

--- a/Tutorial/SliceBridgeJP.md
+++ b/Tutorial/SliceBridgeJP.md
@@ -138,22 +138,25 @@ segref3d_labelmap_anchor_z0p65mm.nii.gz
 SliceBridgeの読み込み画面に表示された`ラベル`の整数値だけを作成すれば十分です。
 必要に応じて、各セグメントを骨盤骨、内閉鎖筋、肛門挙筋などの名称へ変更します。
 
-### 5-5. 各セグメントでFill between slicesを実行する
+### 5-5. 表示中の全セグメントをまとめて補間する
 
-作成したセグメントを1つずつ補間します。
+`Fill between slices`は、選択中のセグメントだけでなく、目のアイコンがONに
+なっているすべてのセグメントを同時に処理します。
 
-1. 補間するセグメントを1つ選択します。
+1. 補間したいすべてのセグメントの目のアイコンをONにします。
 2. `Fill between slices`を選択します。
-3. `Initialize`を押して補間結果を確認します。
-4. 問題がなければ`Apply`を押します。
-5. 次のセグメントを選択し、同じく`Initialize`、`Apply`を行います。
-6. 作成したすべてのセグメントで繰り返します。
+3. `Initialize`を押し、表示中の全セグメントの補間プレビューを確認します。
+4. 問題がなければ`Apply`を1回押します。
 
 ```text
-Segment_1を選択 → Fill between slices → Initialize → Apply
-Segment_2を選択 → Fill between slices → Initialize → Apply
-Segment_3を選択 → Fill between slices → Initialize → Apply
+Segment_1・Segment_2・Segment_3を表示
+→ Fill between slices → Initialize → Apply（各1回）
 ```
+
+青く選択されているセグメントではなく、目のアイコンによる表示状態が処理対象を
+決めます。一部だけを補間したい場合は、対象外のセグメントを非表示にしてから
+`Initialize`を押してください。なお、この補間はSource volumeの濃度ではなく、
+セグメントの形状を用いて計算されます。
 ---
 
 ## 使用上の注意

--- a/slice-bridge/index.html
+++ b/slice-bridge/index.html
@@ -238,8 +238,8 @@
             <li>
               <span>05</span>
               <div>
-                <strong>各セグメントを1つずつ補間</strong>
-                <p>セグメントを選択 → Fill between slices → Initialize → Apply</p>
+                <strong>表示中の全セグメントをまとめて補間</strong>
+                <p>Fill between slices → Initialize → Apply（目のアイコンがONの全セグメント）</p>
               </div>
             </li>
           </ol>

--- a/slice-bridge/index.html
+++ b/slice-bridge/index.html
@@ -238,15 +238,8 @@
             <li>
               <span>05</span>
               <div>
-                <strong>重なりを許可</strong>
-                <p>Modify other segments → <b>Allow overlap</b></p>
-              </div>
-            </li>
-            <li>
-              <span>06</span>
-              <div>
-                <strong>各セグメントの輪郭間を補間</strong>
-                <p>Fill between slices → Initialize → Apply</p>
+                <strong>各セグメントを1つずつ補間</strong>
+                <p>セグメントを選択 → Fill between slices → Initialize → Apply</p>
               </div>
             </li>
           </ol>

--- a/slice-bridge/index.html
+++ b/slice-bridge/index.html
@@ -217,22 +217,36 @@
             <li>
               <span>02</span>
               <div>
-                <strong>Segmentationへ変換</strong>
-                <p>Segmentations → Import labelmap to segmentation</p>
+                <strong>Segment Editorへ移動</strong>
+                <p>Source volumeで読み込んだNIfTIを選択</p>
               </div>
             </li>
             <li>
               <span>03</span>
+              <div>
+                <strong>ラベル1を抽出</strong>
+                <p>Add → Threshold → Rangeを <b>1.00–1.00</b> → Apply</p>
+              </div>
+            </li>
+            <li>
+              <span>04</span>
+              <div>
+                <strong>他のラベルも順に抽出</strong>
+                <p>再度Add → <b>2.00–2.00</b>、<b>3.00–3.00</b>… → 各Apply</p>
+              </div>
+            </li>
+            <li>
+              <span>05</span>
               <div>
                 <strong>重なりを許可</strong>
                 <p>Modify other segments → <b>Allow overlap</b></p>
               </div>
             </li>
             <li>
-              <span>04</span>
+              <span>06</span>
               <div>
-                <strong>輪郭間を補間</strong>
-                <p>Segment Editor → Fill between slices → Initialize → Apply</p>
+                <strong>各セグメントの輪郭間を補間</strong>
+                <p>Fill between slices → Initialize → Apply</p>
               </div>
             </li>
           </ol>


### PR DESCRIPTION
## What changed

- replace the incorrect labelmap-to-segmentation import instructions
- document the actual Segment Editor workflow:
  - load the NIfTI as a Volume
  - create one segment per integer label with Threshold
  - use 1.00–1.00, 2.00–2.00, 3.00–3.00, and so on
  - run Fill between slices → Initialize → Apply separately for every segment
- remove the unnecessary Allow overlap step
- update both the in-app quick guide and the detailed Japanese tutorial

## Validation

- confirmed that both pages contain the integer-label extraction sequence
- confirmed that the old import and Allow overlap instructions are absent
- conversion logic is unchanged